### PR TITLE
Fix build with GCC 10/11 toolchains

### DIFF
--- a/include/linux/compiler-gcc10.h
+++ b/include/linux/compiler-gcc10.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc11.h
+++ b/include/linux/compiler-gcc11.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc5.h
+++ b/include/linux/compiler-gcc5.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc6.h
+++ b/include/linux/compiler-gcc6.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc7.h
+++ b/include/linux/compiler-gcc7.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc8.h
+++ b/include/linux/compiler-gcc8.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/compiler-gcc9.h
+++ b/include/linux/compiler-gcc9.h
@@ -1,0 +1,1 @@
+#include <linux/compiler-gcc4.h>

--- a/include/linux/log2.h
+++ b/include/linux/log2.h
@@ -18,7 +18,7 @@
 /*
  * deal with unrepresentable constant logarithms
  */
-extern __attribute__((const, noreturn))
+extern __attribute__((noreturn))
 int ____ilog2_NaN(void);
 
 /*

--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,7 +637,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \


### PR DESCRIPTION
## Summary

The `stable-v3.x` kernel branch fails to build with GCC 10+ cross-compilers (the default on Ubuntu 22.04+). This PR fixes three issues:

- **compiler-gcc stubs (GCC 5–11)**: The kernel only ships `compiler-gcc3.h` and `compiler-gcc4.h`. Added stub headers for GCC 5–11 that include `compiler-gcc4.h`, unblocking builds with modern toolchains.
- **dtc `yylloc` duplicate symbol**: GCC 10 changed the default to `-fno-common`, causing a link error due to `yylloc` being defined in both `dtc-lexer.lex.c` and `dtc-parser.tab.c`. Marked it `extern` in the lexer.
- **`log2.h` conflicting attributes**: GCC 11 rejects `__attribute__((const, noreturn))` as contradictory. Removed `const` from `____ilog2_NaN`, which is correct — a `noreturn` function has no meaningful return value to cache.

## Notes

One remaining issue: `arch/powerpc/kernel/ptrace.c` triggers `-Warray-bounds` in dead VSX code paths (the Wii has no VSX). Building with `KCFLAGS="-Wno-error=array-bounds"` works around it. A follow-up commit adding this to the arch Makefile would make the build fully hands-off.

## Test plan

- [ ] `make ARCH=powerpc CROSS_COMPILE=powerpc-linux-gnu- wii_defconfig`
- [ ] `make ARCH=powerpc CROSS_COMPILE=powerpc-linux-gnu- KCFLAGS="-Wno-error=array-bounds" -j$(nproc)`
- [ ] Confirm `vmlinux` and `arch/powerpc/boot/zImage` are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)