### PR TITLE
b43: disable QoS for SDIO devices

### DIFF
--- a/drivers/net/wireless/b43/main.c
+++ b/drivers/net/wireless/b43/main.c
@@ -2476,6 +2476,9 @@ start_ieee80211:
 	wl->hw->queues = B43_QOS_QUEUE_NUM;
 	if (!modparam_qos || dev->fw.opensource)
 		wl->hw->queues = 1;
+	/* The Wii's SDIO receive path cannot deliver QoS data frames. */
+	if (b43_bus_host_is_sdio(dev->dev))
+		wl->hw->queues = 1;
 
 	err = ieee80211_register_hw(wl->hw);
 	if (err)


### PR DESCRIPTION
## Summary

- advertise one hardware queue for SDIO-hosted b43 devices
- prevent mac80211 from enabling WMM/QoS on the Wii SDIO path
- leave PCI and other non-SDIO b43 queue configuration unchanged

## Root cause

The Wii's b43 SDIO receive path acknowledges directed QoS data frames in hardware,
but those frames do not reach the driver's PIO receive queue. An independent monitor
capture showed the access point repeatedly sending EAPOL Message 1 as QoS Data FromDS
to the Wii and receiving hardware acknowledgements, while b43 delivered no EAPOL
frame to mac80211.

Advertising one queue suppresses WMM/QoS negotiation. The same access point then sends
ordinary non-QoS data frames, allowing the EAPOL four-way handshake to complete.

## Validation

The behavior in this patch was built into Wii kernel 3.15.10 build #278 and exercised
on real hardware. It completed WPA authentication, obtained a DHCP lease, exchanged
bidirectional ICMP traffic with zero loss, and sustained a public-key OpenSSH root
session. During the SSH workload, b43 PIO reception continued advancing with zero
timeouts, read errors, decryption errors, or bad-PLCP drops.

The deployed test image SHA-256 was
`91982ab5c1c4b67d4cbb74ce035789e6c4d460fa2e270727dd790a17b81f0bf5`.

`git diff --check` passes. Building this isolated commit directly on `stable-v3.x`
is blocked before the affected object is compiled by existing host-toolchain issues:
the branch lacks `linux/compiler-gcc11.h`, and its generated DTC lexer/parser both
define `yylloc` with the current host toolchain.
